### PR TITLE
Added return null to type nullValue instead of zero.

### DIFF
--- a/src/ValueMapper.php
+++ b/src/ValueMapper.php
@@ -118,6 +118,9 @@ class ValueMapper
         switch ($type) {
             case 'booleanValue':
             case 'nullValue':
+                return null;
+                break;
+                
             case 'stringValue':
             case 'doubleValue':
                 return $value;


### PR DESCRIPTION
Added return null to type nullValue instead of zero.

In current version, in update document, is changed null to 0 INTEGER, and this is a problem. And this fix change the value to use null instead of zero.

**PLEASE READ THIS ENTIRE MESSAGE**

Hello, and thank you for your contribution! Please note that this repository is
a read-only split of `googleapis/google-cloud-php`. As such, we are
unable to accept pull requests to this repository.

We welcome your pull request and would be happy to consider it for inclusion in
our library if you follow these steps:

* Clone the parent client library repository:

```sh
$ git clone git@github.com:googleapis/google-cloud-php.git
```

* Move your changes into the correct location in that library. Library code
belongs in `Firestore/src`, and tests in `Firestore/tests`.

* Push the changes in a new branch to a fork, and open a new pull request
[here](https://github.com/googleapis/google-cloud-php).

Thanks again, and we look forward to seeing your proposed change!

The Google Cloud PHP team
